### PR TITLE
Handling "retrieveInnerException" method in AnnotationLibrary when cause...

### DIFF
--- a/src/main/java/org/robotframework/javalib/library/AnnotationLibrary.java
+++ b/src/main/java/org/robotframework/javalib/library/AnnotationLibrary.java
@@ -143,7 +143,7 @@ public class AnnotationLibrary extends KeywordFactoryBasedLibrary<DocumentedKeyw
 
     private RuntimeException retrieveInnerException(RuntimeException e) {
         Throwable cause = e.getCause();
-        if (InvocationTargetException.class.equals(cause.getClass())) {
+        if (cause != null && InvocationTargetException.class.equals(cause.getClass())) {
             Throwable original = cause.getCause();
             return new RuntimeException(original.getMessage(), original);
         }


### PR DESCRIPTION
... object is getting "null"
