### PR TITLE
Update ArgumentConverter.java

### DIFF
--- a/src/main/java/org/robotframework/javalib/reflection/ArgumentConverter.java
+++ b/src/main/java/org/robotframework/javalib/reflection/ArgumentConverter.java
@@ -41,7 +41,7 @@ public class ArgumentConverter implements IArgumentConverter {
     }
 
     private boolean isArrayArgument(Object object) {
-        return object.getClass().isArray();
+        return object != null && object.getClass().isArray();
     }
 
     private Object convertToType(Class<?> clazz, Object object) {


### PR DESCRIPTION
Allowing ${None} to be passed to keywords. currently it results in null pointer exception
